### PR TITLE
Return error if keyserver could not be contacted

### DIFF
--- a/bind/bind.go
+++ b/bind/bind.go
@@ -208,6 +208,9 @@ func DirServerFor(cc upspin.Config, userName upspin.UserName) (upspin.DirServer,
 		return nil, errors.E(op, err)
 	}
 	u, err := key.Lookup(userName)
+	if err != nil {
+		return nil, errors.E(op, err)
+	}
 	if err == nil {
 		endpoints = append(endpoints, u.Dirs...)
 	}


### PR DESCRIPTION
If keyserver could not be reached the current error is:
```
$ upspin ls other@gmail.com/
upspin: ls: client.Lookup:
	Client.DirServer:
	user other@gmail.com: bind.DirServerFor: no directory endpoints found
```

Adding this error handler (setting keyserver to localhst:8443):
```
$ upspin -config ~/upspin/config.dev ls other@gmail.com/
upspin: ls: client.Lookup: I/O error:
	Client.DirServer:
	bind.DirServerFor:
	key/usercache.Lookup:
	key/remote.Lookup("remote,127.0.0.1:8443"):
	rpc.Invoke: Post https://127.0.0.1:8443/api/Key/Lookup: dial tcp 127.0.0.1:8443: getsockopt: connection refused
```