### PR TITLE
Remove hardcoded upspin keyserver. It's defined by default in initconfig.go

### DIFF
--- a/cmd/upspin/signup.go
+++ b/cmd/upspin/signup.go
@@ -179,7 +179,7 @@ func (s *State) registerUser(configFile string) {
 	}
 	signupURL := (&url.URL{
 		Scheme:   "https",
-		Host:     "key.upspin.io",
+		Host:     string(cfg.KeyEndpoint().NetAddr),
 		Path:     "/signup",
 		RawQuery: vals.Encode(),
 	}).String()


### PR DESCRIPTION
#276