### PR TITLE
doc: adding project creation step for gcp

### DIFF
--- a/doc/server_setup_gcp.md
+++ b/doc/server_setup_gcp.md
@@ -45,6 +45,7 @@ Finally, use the `gcloud` tool to enable the required APIs:
 
 ```
 local$ gcloud components install beta
+local$ gcloud projects create example-com
 local$ gcloud config set project example-com
 local$ gcloud auth login
 local$ gcloud beta services enable iam.googleapis.com


### PR DESCRIPTION
When going through the documentation, I was getting an error below that looked like this:

```
ERROR: (gcloud.beta.services.enable) You do not have permission to access service [iam.googleapis.com:enable] (or it may not exist): Project 'example-com' not found or permission denied.
```

I found that the instructions did not explicitly call out a project to create but yet was being referenced. I simply created it and finished the rest of the instructions successfully. This PR simply calls this out. 