### PR TITLE
Fixes an aparent rename/watch race

### DIFF
--- a/cmd/upspinfs/watch.go
+++ b/cmd/upspinfs/watch.go
@@ -362,8 +362,15 @@ func (d *watchedRoot) handleEvent(e *upspin.Event) error {
 	}
 
 	if e.Delete {
-		f.doesNotExist(n.uname)
-		n.deleted = true
+		// If the uname changed between the time we looked it up a few lines
+		// above and here, it means a Rename intervened, and reused the node.
+		// In that case we must not mark the node as deleted. Since Rename already
+		// made sure that old file is no longer used, it should be OK to skip
+		// this part.
+		if n.uname == e.Entry.Name {
+			f.doesNotExist(n.uname)
+			n.deleted = true
+		}
 	} else if n.cf != nil {
 		// If we've changed an open file, forget the
 		// mapping of name to node so that new opens


### PR DESCRIPTION
See issue #590.

During a rename, it is posible that an intervening delete watch
accidentally marks the newly created file as deleted.

The sequence of events is as follows, when renaming file1 to file 2:

- Rename() is called
- filesystem locked
- Rename obtains oldn
- filesystem lock released
- watch gets notification: file1 deleted
- watch locks filesystem
- watch obtains oldn by looking up through path
- watch releases lock
- Rename() grabs lock again
- Rename() fixes up the node map, reuses oldn in the nodemap, this time
  for the new filename
- Rename unlocks and exits
- Watch continues and marks oldn as deleted
- FUSE now thinks that file 2 is deleted.

This commit uses the fact that Rename() will fixup the 'uname' of the node
to a new value to skip marking deletion for reused node.