### PR TITLE
fix(sec): upgrade gopkg.in/yaml.v2 to 2.2.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module upspin.io
 go 1.13
 
 require (
-	github.com/presotto/fuse v0.0.0-20220404205012-944bbcc73d97
 	github.com/NYTimes/gziphandler v0.0.0-20170916004738-97ae7fbaf816
 	github.com/golang/protobuf v0.0.0-20171021043952-1643683e1b54
 	github.com/kr/pretty v0.1.0 // indirect
+	github.com/presotto/fuse v0.0.0-20220404205012-944bbcc73d97
 	github.com/russross/blackfriday v0.0.0-20171011182219-6d1ef893fcb0
 	github.com/stretchr/testify v1.4.0 // indirect
 	golang.org/x/crypto v0.0.0-20191117063200-497ca9f6d64f
@@ -14,5 +14,5 @@ require (
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
 	golang.org/x/text v0.3.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
-	gopkg.in/yaml.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.2.8
 )

--- a/go.sum
+++ b/go.sum
@@ -45,3 +45,5 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogR
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in gopkg.in/yaml.v2 v2.2.2
- [CVE-2019-11254](https://www.oscs1024.com/hd/CVE-2019-11254)


### What did I do？
Upgrade gopkg.in/yaml.v2 from v2.2.2 to 2.2.8 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4<948453219@qq.com>