### PR TITLE
client: fix ReadAt err for short read.

### DIFF
--- a/client/all_test.go
+++ b/client/all_test.go
@@ -325,6 +325,10 @@ func TestFileRandomAccess(t *testing.T) {
 			}
 		}
 	}
+	n, err = f.ReadAt(result, 1)
+	if err == nil {
+		t.Fatalf("expected err==io.EOF, got nil")
+	}
 
 	// Now use a similar algorithm to WriteAt but with ReadAt to check random access.
 	read := make(map[int]bool)

--- a/client/file/file.go
+++ b/client/file/file.go
@@ -170,7 +170,10 @@ func (f *File) readAt(op errors.Op, dst []byte, off int64) (n int, err error) {
 		n += copy(dst[n:], clear[clearIdx:])
 	}
 
-	return n, nil
+	if n < len(dst) {
+		err = io.EOF
+	}
+	return
 }
 
 // Seek implements upspin.File.


### PR DESCRIPTION
When ReadAt returns fewer bytes than requested, it is supposed to return io.EOF rather than nil.

Fixes #648.