### PR TITLE
client: fix Read after ReadAt change

### DIFF
--- a/client/file/file.go
+++ b/client/file/file.go
@@ -95,6 +95,9 @@ func (f *File) Name() upspin.PathName {
 func (f *File) Read(b []byte) (n int, err error) {
 	const op errors.Op = "file.Read"
 	n, err = f.readAt(op, b, f.offset)
+	if err == io.EOF { // TODO(ehg) should this also test " && n < len(b)"?
+		err = nil
+	}
 	if err == nil {
 		f.offset += int64(n)
 	}


### PR DESCRIPTION
My PR #649 unintentionally changed the behavior of Read. This commit is an interim change to repair the immediate damage while I consider a more complete fix. It passes go test -test.run TestFileRandomAccess
as before and now also passes
go test -test.run TestFileZeroFill
but still times out on
go test -test.run TestFileSeek
so definitely should not be considered a complete fix.

More to come, but I'll merge this without review in an attempt to minimize impact on any folks not following the discussion.