### PR TITLE
Update augie image to transparent version for dark themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Upspin
 
-![Augie](doc/images/augie.jpg)
+<img alt="Augie" src="doc/images/augie-transparent.png" width=360>
 
 Documentation: [upspin.io](https://upspin.io/)
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,6 +1,6 @@
 # Upspin
 
-<img src="/images/augie.jpg" width="180" height="218" alt="Home"/>
+<img src="images/augie-transparent.png" width="180" height="218" alt="Home"/>
 
 When did you last...
 


### PR DESCRIPTION
With Github dark theme, the white background of the original image looks off. This makes the front page look better on a dark theme and it was already included in the repo and website. There is no way to keep the markdown as-is and also specify an image size. The old markdown is equivalent to the HTML given. The width matches the old width.

By not including the initial `/` in front of the doc/index.md page you get the benefit that when viewing the index from github the image shows up (as it should also show up in the website)

Live here: https://github.com/BHare1985/upspin/tree/update-augie-transparent