### PR TITLE
add client.SetTimeSequenced and make upspinfs use it

### DIFF
--- a/cmd/upspinfs/fs.go
+++ b/cmd/upspinfs/fs.go
@@ -565,6 +565,7 @@ func (n *node) Remove(context gContext.Context, req *fuse.RemoveRequest) error {
 	for i, de := range n.de {
 		if uname == de.Name {
 			n.de = append(n.de[0:i], n.de[i+1:]...)
+			break
 		}
 	}
 
@@ -777,10 +778,12 @@ func (n *node) Setattr(context gContext.Context, req *fuse.SetattrRequest, resp 
 			return e2e(errors.E(op, n.uname, err))
 		}
 
-		// Set the time.
-		if err := n.f.client.SetTime(n.uname, upspin.TimeFromGo(req.Mtime)); err != nil {
+		// Set the time. Remember the new sequence number.
+		e, err := n.f.client.SetTimeSequenced(n.uname, n.seq, upspin.TimeFromGo(req.Mtime))
+		if err != nil {
 			return e2e(errors.E(op, err))
 		}
+		n.seq = e.Sequence
 		n.attr.Mtime = req.Mtime
 	}
 	// Ignore mode changes.

--- a/upspin/upspin.go
+++ b/upspin/upspin.go
@@ -774,6 +774,14 @@ type Client interface {
 	// not the link target.
 	SetTime(name PathName, t Time) error
 
+	// SetTimeSequenced sets the time in name's DirEntry. 
+	// SetTimeSequenced with SeqIgnore is the same as SetTime.
+	//
+	// A successful SetTimeSequenced returns an incomplete DirEntry (see the
+	// description of AttrIncomplete) containing only the
+	// new sequence number.
+	SetTimeSequenced(name PathName, seq int64, t Time) (*DirEntry, error)
+
 	// Delete deletes the DirEntry associated with the name. The
 	// storage referenced by the DirEntry is not deleted,
 	// although the storage server may garbage collect unreferenced


### PR DESCRIPTION
We recently encountered a FUSE implementation on an ARM mac that did a set mtime in the middle of writing a file.  Since client.SetTime does a Put without a sequence number being returned, upspinfs was no longer new the correct sequence number to use for subsequent Puts.  Therefore I've added a client.SetTimeSequenced, similar to the client.PutSequenced.