### PR TITLE
Proposal: add UnpackBlock to BlockUnpacker interface

### DIFF
--- a/client/clientutil/all_test.go
+++ b/client/clientutil/all_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"math/big"
+	"strconv"
 	"testing"
 
 	"upspin.io/bind"
@@ -126,7 +127,7 @@ func setupTestConfig(t *testing.T) upspin.Config {
 	for i := 0; i < 10; i++ {
 		loc := upspin.Location{
 			Endpoint:  inProcess,
-			Reference: upspin.Reference("ref" + string(i)),
+			Reference: upspin.Reference("ref" + strconv.Itoa(i)),
 		}
 		tLocs = append(tLocs, loc)
 	}

--- a/client/clientutil/all_test.go
+++ b/client/clientutil/all_test.go
@@ -122,7 +122,7 @@ func packdataLen() int {
 	return 2*marshalBufLen + binary.MaxVarintLen64 + 1
 }
 
-func setupTestConfig(t *testing.T) upspin.Config {
+func setupTestConfig(t testing.TB) upspin.Config {
 	// Create some test locations.
 	for i := 0; i < 10; i++ {
 		loc := upspin.Location{

--- a/client/clientutil/benchmark_test.go
+++ b/client/clientutil/benchmark_test.go
@@ -1,0 +1,137 @@
+package clientutil
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"upspin.io/bind"
+	"upspin.io/errors"
+	"upspin.io/test/testfixtures"
+	"upspin.io/upspin"
+)
+
+func BenchmarkReadAll(b *testing.B) {
+	latency := 50 * time.Millisecond
+	cfg, _, entry := setupBenchmark(b, 50<<20, latency)
+
+	for i := 0; i < b.N; i++ {
+		got, err := ReadAll(cfg, entry)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = got
+	}
+}
+
+var (
+	remote = upspin.Endpoint{
+		Transport: upspin.Remote,
+		NetAddr:   "", // ignored
+	}
+)
+
+var bindOnce sync.Once
+
+func setupBenchmark(b *testing.B, size int, latency time.Duration) (upspin.Config, *mockSlowStore, *upspin.DirEntry) {
+	cfg := setupTestConfig(b)
+
+	content := make([]byte, size)
+	rand.Read(content)
+
+	store := &mockSlowStore{
+		content: content,
+		latency: latency,
+	}
+
+	// TODO: this is wrong. All the setupBenchmark is very hacky...
+	bindOnce.Do(func() {
+		// Bind to Remote because inprocess is already used.
+		err := bind.RegisterStoreServer(upspin.Remote, store)
+		if err != nil {
+			b.Fatal(err)
+		}
+	})
+
+	entry := &upspin.DirEntry{
+		Name:       userName + "/testfile",
+		SignedName: userName + "/testfile",
+		Attr:       upspin.AttrNone,
+		Packing:    upspin.PlainPack,
+		Time:       12345,
+		Writer:     userName,
+		Sequence:   upspin.SeqBase,
+	}
+
+	offset := 0
+	for i := 0; offset < len(store.content); i++ {
+		loc := upspin.Location{
+			Endpoint:  remote,
+			Reference: upspin.Reference("ref" + strconv.Itoa(i)),
+		}
+		b := upspin.DirBlock{
+			Offset:   int64(offset),
+			Size:     int64(min(upspin.BlockSize, len(store.content)-offset)),
+			Location: loc,
+		}
+		entry.Blocks = append(entry.Blocks, b)
+		offset += upspin.BlockSize
+	}
+
+	f := cfg.Factotum()
+	dkey := make([]byte, aesKeyLen)
+	sum := make([]byte, sha256.Size)
+	vhash := f.DirEntryHash(entry.SignedName, entry.Link, entry.Attr, entry.Packing, entry.Time, dkey, sum)
+	sig, err := f.FileSign(vhash)
+	if err != nil {
+		b.Fatal(err)
+	}
+	err = pdMarshal(&entry.Packdata, sig, upspin.Signature{})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	return cfg, store, entry
+}
+
+type mockSlowStore struct {
+	testfixtures.DummyStoreServer
+	content []byte
+	latency time.Duration
+}
+
+func (s *mockSlowStore) Get(ref upspin.Reference) ([]byte, *upspin.Refdata, []upspin.Location, error) {
+	time.Sleep(s.latency)
+
+	n := strings.TrimPrefix(string(ref), "ref")
+	number, err := strconv.Atoi(n)
+	if err != nil || number < 0 {
+		return nil, nil, nil, errors.E(errors.NotExist)
+	}
+
+	offset := number * upspin.BlockSize
+	if offset >= len(s.content) {
+		return nil, nil, nil, errors.E(errors.NotExist)
+	}
+
+	end := min(offset+upspin.BlockSize, len(s.content))
+	refdata := &upspin.Refdata{
+		Reference: ref,
+	}
+	return s.content[offset:end], refdata, nil, nil
+}
+
+func (s *mockSlowStore) Dial(upspin.Config, upspin.Endpoint) (upspin.Service, error) {
+	return s, nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/client/file/file_test.go
+++ b/client/file/file_test.go
@@ -155,3 +155,6 @@ func (d *dummyClient) Rename(oldName, newName upspin.PathName) (*upspin.DirEntry
 func (d *dummyClient) SetTime(name upspin.PathName, t upspin.Time) error {
 	return nil
 }
+func (d *dummyClient) SetTimeSequenced(name upspin.PathName, seq int64, t upspin.Time) (*upspin.DirEntry, error) {
+	return nil, nil
+}

--- a/pack/ee/ee.go
+++ b/pack/ee/ee.go
@@ -342,17 +342,22 @@ type blockUnpacker struct {
 
 func (bp *blockUnpacker) Unpack(ciphertext []byte) (cleartext []byte, err error) {
 	const op errors.Op = "pack/ee.blockUnpacker.Unpack"
+	return bp.UnpackBlock(ciphertext, bp.Block)
+}
+
+func (bp *blockUnpacker) UnpackBlock(ciphertext []byte, n int) (cleartext []byte, err error) {
+	const op errors.Op = "pack/ee.blockUnpacker.UnpackBlock"
 	// Validate checksum.
 	b := sha256.Sum256(ciphertext)
 	sum := b[:]
-	if got, want := sum, bp.entry.Blocks[bp.Block].Packdata; !bytes.Equal(got, want) {
+	if got, want := sum, bp.entry.Blocks[n].Packdata; !bytes.Equal(got, want) {
 		return nil, errors.E(op, bp.entry.Name, "checksum mismatch")
 	}
 
 	cleartext = bp.buf.Bytes(len(ciphertext))
 
 	// Decrypt.
-	if err := crypt(cleartext, ciphertext, bp.cipher, bp.entry.Blocks[bp.Block].Offset); err != nil {
+	if err := crypt(cleartext, ciphertext, bp.cipher, bp.entry.Blocks[n].Offset); err != nil {
 		return nil, errors.E(op, bp.entry.Name, err)
 	}
 

--- a/pack/eeintegrity/eeintegrity.go
+++ b/pack/eeintegrity/eeintegrity.go
@@ -216,10 +216,15 @@ type blockUnpacker struct {
 // Unpack implements upspin.BlockUnpacker.
 func (bp *blockUnpacker) Unpack(ciphertext []byte) (cleartext []byte, err error) {
 	const op errors.Op = "pack/eeintegrity.blockUpacker.Unpack"
+	return bp.UnpackBlock(ciphertext, bp.Block)
+}
+
+func (bp *blockUnpacker) UnpackBlock(ciphertext []byte, n int) (cleartext []byte, err error) {
+	const op errors.Op = "pack/eeintegrity.blockUpacker.UnpackBlock"
 	// Validate checksum.
 	b := sha256.Sum256(ciphertext)
 	sum := b[:]
-	if got, want := sum, bp.entry.Blocks[bp.Block].Packdata; !bytes.Equal(got, want) {
+	if got, want := sum, bp.entry.Blocks[n].Packdata; !bytes.Equal(got, want) {
 		return nil, errors.E(op, bp.entry.Name, "checksum mismatch")
 	}
 

--- a/pack/plain/plain.go
+++ b/pack/plain/plain.go
@@ -181,6 +181,10 @@ type blockUnpacker struct {
 }
 
 func (bp *blockUnpacker) Unpack(ciphertext []byte) (cleartext []byte, err error) {
+	return bp.UnpackBlock(ciphertext, 0)
+}
+
+func (bp *blockUnpacker) UnpackBlock(ciphertext []byte, _ int) (cleartext []byte, err error) {
 	cleartext = ciphertext
 	return
 }

--- a/upspin/upspin.go
+++ b/upspin/upspin.go
@@ -198,8 +198,19 @@ type BlockUnpacker interface {
 	// Unpack takes ciphertext returns the cleartext. If appropriate, the
 	// result is verified as correct according to the block's Packdata.
 	//
-	// The cleartext slice remains valid until the next call to Unpack.
+	// The cleartext slice remains valid until the next call to Unpack or
+	// UnpackBlock.
 	Unpack(ciphertext []byte) (cleartext []byte, err error)
+
+	// UnpackBlock takes ciphertext and the block number and returns the
+	// cleartext. If appropriate, the result is verified as correct according
+	// to the block's Packdata.
+	//
+	// UnpackBlock, different from Upack, is not affected by NextBlock.
+	//
+	// The cleartext slice remains valid until the next call to Unpack or
+	// UnpackBlock.
+	UnpackBlock(ciphertext []byte, n int) (cleartext []byte, err error)
 
 	// Close releases any resources associated with the unpacking
 	// operation.
@@ -774,7 +785,7 @@ type Client interface {
 	// not the link target.
 	SetTime(name PathName, t Time) error
 
-	// SetTimeSequenced sets the time in name's DirEntry. 
+	// SetTimeSequenced sets the time in name's DirEntry.
 	// SetTimeSequenced with SeqIgnore is the same as SetTime.
 	//
 	// A successful SetTimeSequenced returns an incomplete DirEntry (see the


### PR DESCRIPTION
This PR is not intended to be merged, it is just a proposal with code examples.

Although there is a lot of code, the proposal is only about expanding the BlockUnpacker interface and implementing the new method in `pack/{ee,eeintegrity,plain}`.

# Proposal

Add the following method to the `upspin.BlockUnpacker` interface:
```go
        // UnpackBlock takes ciphertext and the block number and returns the
	// cleartext. If appropriate, the result is verified as correct according
	// to the block's Packdata.
	//
	// UnpackBlock, different from Upack, is not affected by NextBlock.
	//
	// The cleartext slice remains valid until the next call to Unpack or
	// UnpackBlock.
	UnpackBlock(ciphertext []byte, n int) (cleartext []byte, err error)
```

UnpackBlock works like Unpack but is independent from method NextBlock.
The fact that those methods are independent make possible (or at least more ergonomic) to call those functions concurrently.

# Motivation

Why do I need to call NextBlock and UnpackBlock concurrently?

Performance.
I have a remote Upspin server that uses a S3 like storage, so there is the latency from my laptop to the Upspin server + the latency from the storage server to get data from the S3 storage. I guess I have a latency of ~100ms to get a block from my Upspin server.

The current `client/clientutil.ReadAll()` function fetch and read each block of 1MB (or other BlockSize) sequentially. So if I read a file of 50MB size I take a penalty of 50 * 100ms = 5s just waiting for latency reasons.

If I could use NextBlock and UnpackBlock concurrently I could fetch N blocks concurrently and then just unpack sequentially, using some sliding window algorithm for example.

`client/clientutil.ReadAll()` is not the only function that could be parallelized I suspect that the client File.Read() could benefit from that too, but I didn't dive deeper.

# Benchmark

As I said in the beginning of this proposal, this PR contains a lot of code that is not directly related to the proposal.

I wrote a proof of concept of a concurrently `ReadAll()` function and a simple Benchmark, both of which are not well written and probably contains bugs, but I think they are useful to show the intuition and the performance gains.

See `client/clientutil/readall.go` and `client/clientutil/benchmark_test.go`.

The benchmark results I got simulating a server with 50ms of latency:
```
goos: darwin
goarch: arm64
pkg: upspin.io/client/clientutil
cpu: Apple M3 Pro
           │   old.txt    │               new.txt               │
           │    sec/op    │   sec/op     vs base                │
ReadAll-11   2694.4m ± 0%   225.0m ± 1%  -91.65% (p=0.000 n=10)

           │   old.txt    │               new.txt                │
           │     B/op     │     B/op      vs base                │
ReadAll-11   316.8Mi ± 0%   276.7Mi ± 0%  -12.65% (p=0.000 n=10)

           │  old.txt   │              new.txt               │
           │ allocs/op  │ allocs/op   vs base                │
ReadAll-11   492.0 ± 1%   351.0 ± 1%  -28.66% (p=0.000 n=10)
```
