### PR TITLE
upspin: add UnpackBlock to the BlockUnpacker interface

### DIFF
--- a/pack/eeintegrity/eeintegrity.go
+++ b/pack/eeintegrity/eeintegrity.go
@@ -216,17 +216,33 @@ type blockUnpacker struct {
 // Unpack implements upspin.BlockUnpacker.
 func (bp *blockUnpacker) Unpack(ciphertext []byte) (cleartext []byte, err error) {
 	const op errors.Op = "pack/eeintegrity.blockUpacker.Unpack"
+	cleartext = bp.buf.Bytes(len(ciphertext))
+	if err := bp.unpackBlock(op, cleartext, ciphertext, bp.Block); err != nil {
+		return nil, err
+	}
+	return cleartext, nil
+}
+
+// UnpackBlock implements upspin.BlockUnpacker.
+func (bp *blockUnpacker) UnpackBlock(cleartext, ciphertext []byte, n int) error {
+	const op errors.Op = "pack/eeintegrity.blockUpacker.UnpackBlock"
+	if len(cleartext) < len(ciphertext) {
+		panic("UnpackBlock: len(cleartext) should be >= len(ciphertext)")
+	}
+	return bp.unpackBlock(op, cleartext, ciphertext, n)
+}
+
+func (bp *blockUnpacker) unpackBlock(op errors.Op, cleartext, ciphertext []byte, n int) error {
 	// Validate checksum.
 	b := sha256.Sum256(ciphertext)
 	sum := b[:]
-	if got, want := sum, bp.entry.Blocks[bp.Block].Packdata; !bytes.Equal(got, want) {
-		return nil, errors.E(op, bp.entry.Name, "checksum mismatch")
+	if got, want := sum, bp.entry.Blocks[n].Packdata; !bytes.Equal(got, want) {
+		return errors.E(op, bp.entry.Name, "checksum mismatch")
 	}
 
-	cleartext = bp.buf.Bytes(len(ciphertext))
 	copy(cleartext, ciphertext)
 
-	return cleartext, nil
+	return nil
 }
 
 func (bp *blockUnpacker) Close() error {

--- a/pack/plain/plain.go
+++ b/pack/plain/plain.go
@@ -180,6 +180,14 @@ type blockUnpacker struct {
 	internal.BlockTracker // provides NextBlock method and Block field
 }
 
+func (bp *blockUnpacker) UnpackBlock(cleartext, ciphertext []byte, _ int) error {
+	if len(cleartext) < len(ciphertext) {
+		panic("UnpackBlock: len(cleartext) should be >= len(ciphertext)")
+	}
+	copy(cleartext, ciphertext)
+	return nil
+}
+
 func (bp *blockUnpacker) Unpack(ciphertext []byte) (cleartext []byte, err error) {
 	cleartext = ciphertext
 	return

--- a/upspin/upspin.go
+++ b/upspin/upspin.go
@@ -201,6 +201,15 @@ type BlockUnpacker interface {
 	// The cleartext slice remains valid until the next call to Unpack.
 	Unpack(ciphertext []byte) (cleartext []byte, err error)
 
+	// UnpackBlock takes the ciphertext and the block number, unpacks it
+	// into cleartext and if appropriate the result is verified as correct
+	// according to the block's Packdata.
+	//
+	// If len(cleartext) < len(ciphertext) UnpackBlock panics.
+	//
+	// UnpackBlock is not affected by NextBlock.
+	UnpackBlock(cleartext, ciphertext []byte, n int) error
+
 	// Close releases any resources associated with the unpacking
 	// operation.
 	Close() error
@@ -774,7 +783,7 @@ type Client interface {
 	// not the link target.
 	SetTime(name PathName, t Time) error
 
-	// SetTimeSequenced sets the time in name's DirEntry. 
+	// SetTimeSequenced sets the time in name's DirEntry.
 	// SetTimeSequenced with SeqIgnore is the same as SetTime.
 	//
 	// A successful SetTimeSequenced returns an incomplete DirEntry (see the


### PR DESCRIPTION
This PR implements the proposal discussed in #671 with a few modifications:

The UnpackBlock method doesn't return the cleartext, instead it receives a slice to write the cleartext to. This allows the user to call UnpackBlock concurrently.

The UnpackBlock method panics when len(cleartext) < len(ciphertext). I am not sure if panic is the right choice here, it's possible to return an error, but I think this would only occur if the code has a bug.