### PR TITLE
[upspinserver] added field for keyserver in config

### DIFF
--- a/serverutil/upspinserver/main.go
+++ b/serverutil/upspinserver/main.go
@@ -112,6 +112,13 @@ func initServer(mode initMode) (*subcmd.ServerConfig, upspin.Config, *perm.Perm,
 	cfg = config.SetDirEndpoint(cfg, ep)
 	cfg = config.SetStoreEndpoint(cfg, ep)
 
+	if "" != serverConfig.KeyServer {
+		cfg = config.SetKeyEndpoint(cfg, upspin.Endpoint{
+			Transport: upspin.Remote,
+			NetAddr:   serverConfig.KeyServer,
+		})
+	}
+
 	storeCfg := config.SetPacking(cfg, upspin.EEIntegrityPack)
 	dirCfg := config.SetPacking(cfg, upspin.EEPack)
 

--- a/subcmd/server.go
+++ b/subcmd/server.go
@@ -24,6 +24,9 @@ type ServerConfig struct {
 
 	// StoreConfig specifies the configuration options for the StoreServer.
 	StoreConfig []string
+
+	// Optionally, set the host and port for the KeyServer for lookups.
+	KeyServer upspin.NetAddr
 }
 
 // ServerConfigFile specifies the file name of the JSON-encoded ServerConfig.


### PR DESCRIPTION
With the decomissioning of the upspin.io servers,
it becomes necessary to run a dedicated keyserver
and point to it in the configuration of various
upspin components.

While this is possible for the upspin-client and
their configuration file (usually in ~/upspin/config),
the configuration file (serverconfig.json) for
various storage servers does not have an option to
refer to a keyserver and therefore always use the
hardcoded 'keys.upspin.io:443' for key lookups.

This commit adds a field 'KeyServer' to the server
configuration, as upspin.NetAddr, and when set,
will be used in upspinserver implementations.

Note:  This commit is an intermediate step
towards two additional, complementary goals:

1.) implement a local inproc-keyserver, embedded into
    the services, reading upspin.User from local files.

2.) add DNS-based lookup of a keyserver for a domain